### PR TITLE
Add to busy_servers when we skip a server with a recent redirect

### DIFF
--- a/Matchmaker/matchmaker.js
+++ b/Matchmaker/matchmaker.js
@@ -159,8 +159,10 @@ if(enableRESTAPI) {
 				// chance of redirecting 2+ users to the same SS before they click Play.
 				// In other words, give the user 10 seconds to click play button the claim the server.
 				if( cirrusServer.hasOwnProperty('lastRedirect')) {
-					if( ((Date.now() - cirrusServer.lastRedirect) / 1000) < 10 )
+					if( ((Date.now() - cirrusServer.lastRedirect) / 1000) < 10 ){
+						busy_servers.push(`${cirrusServer.address}:${cirrusServer.port}`);
 						continue;
+					}
 				}
 				available_servers.push(`${cirrusServer.address}:${cirrusServer.port}`);
 			} else {


### PR DESCRIPTION
Small fix to /stats, when a server has a recent redirect we assume it is busy in `getAvailableCirrusServer`, make sure `/stats` has the same logic